### PR TITLE
Update agent release version

### DIFF
--- a/docker-compose-mysql.yaml
+++ b/docker-compose-mysql.yaml
@@ -4,7 +4,7 @@ services:
   agent:
     links:
      - mysql
-    image: datadog/agent:7.30.0
+    image: datadog/agent:7.35.0
     environment:
      - DD_API_KEY=${DD_API_KEY}
     volumes:

--- a/docker-compose-postgres.yaml
+++ b/docker-compose-postgres.yaml
@@ -4,7 +4,7 @@ services:
   agent:
     links:
      - postgres
-    image: datadog/agent:7.31.0-rc.7
+    image: datadog/agent:7.35.0
     environment:
      - DD_API_KEY=${DD_API_KEY}
     volumes:


### PR DESCRIPTION
Minimum required version for DBM right now is 7.33.0+. Updated to 7.35.0 as it was just released Thursday. (https://github.com/DataDog/datadog-agent/releases/tag/7.35.0)