### PR TITLE
Fix schema collection for Postgres and MySQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: mysql
 mysql: check-apikey
-	docker-compose -f docker-compose-mysql.yaml up --build agent app
+	docker-compose -p dd-dbm-mysql -f docker-compose-mysql.yaml up --build agent app
 
 .PHONY: postgres
 postgres: check-apikey
-	docker-compose -f docker-compose-postgres.yaml up --build agent app
+	docker-compose -p dd-dbm-postgres -f docker-compose-postgres.yaml up --build agent app
 
 .PHONY: clean
 clean:
-	docker-compose -f docker-compose-postgres.yaml down --rmi local
-	docker-compose -f docker-compose-mysql.yaml down --rmi local
-	docker-compose -f docker-compose-postgres.yaml rm -f
-	docker-compose -f docker-compose-mysql.yaml rm -f
+	docker-compose -p dd-dbm-postgres -f docker-compose-postgres.yaml down --rmi local
+	docker-compose -p dd-dbm-mysql -f docker-compose-mysql.yaml down --rmi local
+	docker-compose -p dd-dbm-postgres -f docker-compose-postgres.yaml rm -f
+	docker-compose -p dd-dbm-mysql -f docker-compose-mysql.yaml rm -f
 
 .PHONY: check-apikey
 check-apikey:

--- a/docker-compose-postgres.yaml
+++ b/docker-compose-postgres.yaml
@@ -68,5 +68,6 @@ services:
           "query_metrics": {"enabled": true},
           "query_activity": {"enabled": true},
           "collect_schemas": {"enabled": true},
+          "database_autodiscovery": {"enabled": true},
           "tags": ["env:development", "service:orders-app"]
         }]

--- a/mysql/initdb/2_mysql-dbm-setup.sql
+++ b/mysql/initdb/2_mysql-dbm-setup.sql
@@ -1,4 +1,7 @@
 GRANT SELECT ON performance_schema.* TO 'datadog'@'%';
+GRANT SELECT ON mysql.innodb_index_stats TO 'datadog'@'%';
+GRANT SELECT ON mysql.innodb_table_stats TO 'datadog'@'%';
+GRANT SELECT ON orders.* TO 'datadog'@'%';
 GRANT CREATE TEMPORARY TABLES ON `datadog`.* TO 'datadog'@'%';
 
 

--- a/postgres/initdb/02_setup.sh
+++ b/postgres/initdb/02_setup.sh
@@ -39,7 +39,6 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" orders <<-'EOSQL'
     CREATE SCHEMA datadog;
     GRANT USAGE ON SCHEMA datadog TO datadog;
     GRANT USAGE ON SCHEMA public TO datadog;
-    GRANT SELECT ON ALL TABLES IN SCHEMA public TO datadog;
     ALTER DEFAULT PRIVILEGES FOR ROLE orders IN SCHEMA public GRANT SELECT ON TABLES TO datadog;
 
     CREATE OR REPLACE FUNCTION datadog.explain_statement(l_query text, out explain JSON) RETURNS SETOF JSON AS

--- a/postgres/initdb/02_setup.sh
+++ b/postgres/initdb/02_setup.sh
@@ -34,11 +34,12 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" postgres <<-'EOSQL'
 EOSQL
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" orders <<-'EOSQL'
+    CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
     GRANT pg_monitor TO datadog;
     CREATE SCHEMA datadog;
     GRANT USAGE ON SCHEMA datadog TO datadog;
     GRANT USAGE ON SCHEMA public TO datadog;
-    -- Allow datadog to see tables created by the orders user after startup
+    GRANT SELECT ON ALL TABLES IN SCHEMA public TO datadog;
     ALTER DEFAULT PRIVILEGES FOR ROLE orders IN SCHEMA public GRANT SELECT ON TABLES TO datadog;
 
     CREATE OR REPLACE FUNCTION datadog.explain_statement(l_query text, out explain JSON) RETURNS SETOF JSON AS


### PR DESCRIPTION
## Summary

- **Postgres — `pg_stat_statements` in `orders` DB**: The agent collects query metrics and samples by querying `pg_stat_statements`. The extension was only installed in the `postgres` maintenance DB; installing it in `orders` (where the app runs) lets the agent collect data from app queries.
- **Postgres — `GRANT SELECT ON ALL TABLES`**: Added explicit grant alongside the existing `ALTER DEFAULT PRIVILEGES`, which only covers tables created after init. Both are needed.
- **Postgres — `database_autodiscovery`**: Without this, the agent only inspects the connected database (`postgres`). Enabling autodiscovery causes it to connect to all databases including `orders` for schema collection.
- **MySQL — `SELECT ON orders.*`**: MySQL's `information_schema` only surfaces tables the querying user has privileges on. Without this grant the agent sees no tables to collect.
- **MySQL — `SELECT ON mysql.innodb_index_stats/innodb_table_stats`**: These system tables are queried for index metadata and are not covered by the `performance_schema.*` grant.
- **Makefile — project names**: Added `-p dd-dbm-postgres` / `-p dd-dbm-mysql` so both stacks can run simultaneously without container name collisions.

## Test plan
- [ ] `docker-compose -p dd-dbm-postgres -f docker-compose-postgres.yaml down -v && make postgres` — verify schemas appear in DBM UI within ~5 min
- [ ] `docker-compose -p dd-dbm-mysql -f docker-compose-mysql.yaml down -v && make mysql` — verify schemas appear in DBM UI
- [ ] Run both `make postgres` and `make mysql` simultaneously — verify no container conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)