### PR TITLE
terraform: add MySQL examples (EC2, ECS Fargate, Amazon EKS)

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -23,6 +23,8 @@ The directory tree is organized by **cloud**, since one Terraform module typical
 | Postgres | AWS | ECS Fargate | [`postgres/aws/ecs-fargate/`](./postgres/aws/ecs-fargate/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 | Postgres | AWS | Amazon EKS (EC2 nodes) | [`postgres/aws/amazon-eks/`](./postgres/aws/amazon-eks/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 | Postgres | AWS | EC2 | [`postgres/aws/ec2/`](./postgres/aws/ec2/) | `rds`, `aurora`, `self_hosted` (on EC2) |
+| MySQL | AWS | ECS Fargate | [`mysql/aws/ecs-fargate/`](./mysql/aws/ecs-fargate/) | `rds`, `aurora`, `self_hosted` (on EC2) |
+| MySQL | AWS | Amazon EKS (EC2 nodes) | [`mysql/aws/amazon-eks/`](./mysql/aws/amazon-eks/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 | MySQL | AWS | EC2 | [`mysql/aws/ec2/`](./mysql/aws/ec2/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 
 Combinations not in this table render a "Coming soon" stub on the docs page; in this repo they simply have no directory yet.
@@ -66,4 +68,4 @@ Every example follows the same file convention:
 
 - [Set up Database Monitoring with Terraform](https://docs.datadoghq.com/database_monitoring/setup_agent_terraform/) — the docs page these examples back
 - [Database Monitoring](https://docs.datadoghq.com/database_monitoring/) — DBM product overview
-- [`_bootstrap/`](./_bootstrap/) — Terraform for the prerequisites these examples assume (RDS instance with DBM-ready parameter group, the `datadog` Postgres user, etc.)
+- [`_bootstrap/`](./_bootstrap/) — Terraform for the prerequisites these examples assume (RDS instance with DBM-ready parameter group, the `datadog` database user, etc.)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,7 +12,7 @@ The directory tree is organized by **cloud**, since one Terraform module typical
 
 | Slot | Values used today | Maps to docs `db_hosting` filter |
 |---|---|---|
-| `<database>` | `postgres` | `database` |
+| `<database>` | `postgres`, `mysql` | `database` |
 | `<cloud>` | `aws` | `rds`, `aurora`, `self_hosted` (when self-hosted on EC2 in the same VPC) |
 | `<agent-runtime>` | `ecs-fargate`, `amazon-eks`, `ec2` | `agent_runtime` |
 
@@ -23,6 +23,7 @@ The directory tree is organized by **cloud**, since one Terraform module typical
 | Postgres | AWS | ECS Fargate | [`postgres/aws/ecs-fargate/`](./postgres/aws/ecs-fargate/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 | Postgres | AWS | Amazon EKS (EC2 nodes) | [`postgres/aws/amazon-eks/`](./postgres/aws/amazon-eks/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 | Postgres | AWS | EC2 | [`postgres/aws/ec2/`](./postgres/aws/ec2/) | `rds`, `aurora`, `self_hosted` (on EC2) |
+| MySQL | AWS | EC2 | [`mysql/aws/ec2/`](./mysql/aws/ec2/) | `rds`, `aurora`, `self_hosted` (on EC2) |
 
 Combinations not in this table render a "Coming soon" stub on the docs page; in this repo they simply have no directory yet.
 
@@ -56,7 +57,7 @@ Every example follows the same file convention:
 ## Conventions across all examples
 
 - **No database is provisioned.** You bring the RDS/Cloud SQL/etc. instance.
-- **The Postgres `datadog` user is created out-of-band.** Each example's README has the exact SQL to run against your database.
+- **The `datadog` database user is created out-of-band.** Each example's README has the exact SQL to run against your database.
 - **Secrets land in Terraform state.** Examples mark `sensitive` on inputs and document the production hardening path (Secrets Manager, External Secrets Operator, etc.) in each README's *Security note* section.
 - **Terraform >= 1.5** and the relevant cloud provider CLI authenticated.
 - **`terraform destroy` is reversible for the agent side only.** Your database, VPC, and the in-database `datadog` user are never touched.

--- a/terraform/mysql/aws/amazon-eks/.gitignore
+++ b/terraform/mysql/aws/amazon-eks/.gitignore
@@ -1,0 +1,16 @@
+# Sensitive credentials -- never commit these
+*.tfvars
+!*.tfvars.example
+
+# Terraform state (contains sensitive data)
+*.tfstate
+*.tfstate.*
+.terraform/
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/terraform/mysql/aws/amazon-eks/README.md
+++ b/terraform/mysql/aws/amazon-eks/README.md
@@ -1,0 +1,225 @@
+# DBM on Amazon EKS (EC2 node groups) — MySQL in AWS
+
+Stands up the Datadog Agent on an **AWS EKS cluster with EC2 node groups** with **Database Monitoring** enabled, configured to monitor an **existing MySQL database in AWS** via a **cluster check**.
+
+Companion to the Postgres EKS sibling ([`../../postgres/aws/amazon-eks/`](../../postgres/aws/amazon-eks/)) — different database, same agent runtime.
+
+Supports two modes — pick one:
+
+- **Bring your own EKS cluster (default).** Set `eks_cluster_name` and `eks_node_security_group_id` in `terraform.tfvars`. The template installs the Datadog Helm chart into your cluster, opens 3306 ingress on the database's SG from the node SG, and creates ~3 resources. Apply takes ~3 minutes.
+- **Provision a new EKS cluster (greenfield).** Leave `eks_cluster_name` empty and supply `private_subnet_ids` instead. The template provisions an EKS cluster + managed node group + IAM, then installs the agent. ~13 resources, ~15-20 minute apply, **adds ongoing AWS cost — see [Cost](#cost) below**.
+
+Either way, this template does **not** provision the database, the VPC, or the MySQL `datadog` user. The MySQL check runs on the Cluster Check Runner pods so DBM data is emitted once cluster-wide, not per node.
+
+## Hosting coverage
+
+This module works for any MySQL database reachable inside an AWS VPC by security group. Point `db_endpoint` and `db_security_group_id` at:
+
+- **Amazon RDS MySQL** — the RDS endpoint and the RDS security group.
+- **Amazon Aurora MySQL** — the Aurora cluster writer endpoint and the Aurora cluster's security group.
+- **Self-hosted MySQL on EC2 in the same VPC** — the EC2 instance hostname/IP and the security group attached to the MySQL EC2 instance.
+
+For MySQL self-hosted **outside AWS** (on-premises, in another cloud), this AWS-side example does not apply.
+
+## Cost
+
+If you are **bringing your own EKS cluster**, this template adds **no AWS cost** — only a single security-group rule, a Kubernetes namespace, and a Helm release.
+
+If you are **provisioning a new EKS cluster** via this template, the new infrastructure has ongoing cost regardless of utilization:
+
+| Component | Cost (us-east-1, on-demand) |
+|---|---|
+| EKS control plane | **$0.10/hr (~$73/month)** — billed continuously while the cluster exists, even when idle |
+| Managed node group EC2 instances | `node_desired_count` × instance hourly rate. Default `t3.small` × 2 ≈ $0.04/hr (~$30/month). |
+| EBS gp3 volumes attached to nodes | `node_desired_count` × `node_disk_size_gb` × $0.08/GB-month. Default 2 × 20 GiB ≈ $3/month. |
+| Network egress, NAT, EIPs | depends on traffic |
+
+**Order-of-magnitude total for the greenfield default**: ~$110/month (~$3.60/day).
+
+This is meant for a one-off setup or a long-lived demo cluster. If you only need DBM for a few hours of testing, run `terraform destroy` when you're done — destroy in greenfield mode tears down the EKS cluster and the node group along with the agent install (see [Teardown](#teardown)).
+
+If you already operate EKS for other workloads, **always prefer BYO mode** — there is no reason to spin up a second cluster just for DBM.
+
+## Architecture
+
+```
+   ┌────────────────────────── existing VPC ──────────────────────────┐
+   │                                                                  │
+   │   EKS cluster (EC2 node groups)               ┌──────────────┐   │
+   │   ┌────────────────────────┐    3306          │    MySQL     │   │
+   │   │  Cluster Check Runner  │ ───────────────▶ │  (RDS, or    │   │
+   │   │  datadog/agent:7       │                  │   Aurora, or │   │
+   │   │  mysql check           │                  │   self-      │   │
+   │   │  cluster_check: true   │                  │   hosted EC2)│   │
+   │   └─────────┬──────────────┘                  └──────────────┘   │
+   │             │                                                    │
+   │   ┌─────────┴──────────────┐                                     │
+   │   │  Cluster Agent         │                                     │
+   │   │  dispatches checks     │                                     │
+   │   └─────────┬──────────────┘                                     │
+   │             │                                                    │
+   │   ┌─────────┴──────────────┐                                     │
+   │   │  node Agent DaemonSet  │ (host metrics, kube checks)         │
+   │   └─────────┬──────────────┘                                     │
+   │             │ egress (NAT or VPC endpoint)                       │
+   └─────────────┼────────────────────────────────────────────────────┘
+                 ▼
+            Datadog (DD_SITE)
+```
+
+## Prerequisites
+
+### For both modes
+
+- **Terraform >= 1.5** with the `aws`, `helm`, and `kubernetes` providers.
+- **An existing MySQL database** (MySQL 5.7+ or 8.0+) in a VPC reachable from the EKS nodes.
+- **The MySQL `datadog` user** created on the database — see *Manual SQL* below.
+- A **Datadog API key** for the destination org (and an app key if you want Cluster Agent features beyond DBM).
+- **RDS parameter group** (or `my.cnf` for self-hosted) with the following parameters set (Performance Schema is the source of truth for DBM):
+
+  | Parameter | Value | Why |
+  |---|---|---|
+  | `performance_schema` | `1` | Required for query metrics, samples, and activity |
+  | `max_digest_length` | `4096` | Larger captured SQL text |
+  | `performance_schema_max_digest_length` | `4096` | Match `max_digest_length` |
+  | `performance_schema_max_sql_text_length` | `4096` | Larger captured SQL text |
+
+  Changing `performance_schema` requires an RDS reboot.
+
+### Additionally for BYO mode
+
+- **AWS credentials** with permission to create security-group rules and to call `eks:DescribeCluster` / `eks:GetToken` for the target cluster, plus `kubectl`-equivalent permissions inside the cluster (typically the same IAM principal mapped via `aws-auth` or an EKS access entry).
+- **An existing EKS cluster with EC2 node groups**. The node group's security group ID is required.
+- **Cluster networking** that lets the worker nodes reach `*.${DD_SITE}` over 443 (NAT gateway or a VPC endpoint).
+
+### Additionally for greenfield mode
+
+- **AWS credentials** with permission to create EKS clusters, IAM roles + policy attachments, EKS managed node groups, and security-group rules.
+- **At least 2 private subnets in different AZs** in the database's VPC, with NAT egress so the control plane and worker nodes can reach Datadog and ECR. Pass them via `private_subnet_ids`.
+- **Awareness of the ongoing cost** — see [Cost](#cost).
+
+## Manual SQL
+
+Run this once against the MySQL instance using the master user.
+
+```sql
+-- Create the user
+CREATE USER datadog@'%' IDENTIFIED BY '<PASSWORD>';
+ALTER USER datadog@'%' WITH MAX_USER_CONNECTIONS 5;
+
+-- Required for monitoring
+GRANT REPLICATION CLIENT ON *.* TO datadog@'%';
+GRANT PROCESS ON *.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
+
+-- Required for DBM (host metadata + explain plan capture)
+GRANT SELECT ON mysql.user TO datadog@'%';
+
+CREATE SCHEMA IF NOT EXISTS datadog;
+GRANT EXECUTE ON datadog.* TO datadog@'%';
+GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
+
+DELIMITER $$
+CREATE PROCEDURE datadog.explain_statement(IN query TEXT)
+    SQL SECURITY DEFINER
+BEGIN
+    SET @explain := CONCAT('EXPLAIN FORMAT=json ', query);
+    PREPARE stmt FROM @explain;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+END $$
+DELIMITER ;
+
+-- Performance Schema consumers (run as master user, not as datadog)
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
+```
+
+Reference: [Setup DBM for MySQL managed by AWS](https://docs.datadoghq.com/database_monitoring/setup_mysql/rds/).
+
+## Apply
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — pick BYO or greenfield (see the file header) and fill
+# in the rest (db_security_group_id, db_endpoint, datadog_user_password,
+# datadog_api_key, ...).
+
+terraform init
+terraform plan
+terraform apply
+```
+
+What gets created depends on the mode:
+
+- **BYO mode** (`eks_cluster_name` set) — ~3 resources visible in Terraform: a `kubernetes_namespace`, a `helm_release` (which deploys the node Agent DaemonSet, Cluster Agent, and Cluster Check Runner inside your cluster), and a single `aws_security_group_rule` on the database's SG. Apply takes ~3 minutes.
+- **Greenfield mode** (`eks_cluster_name = ""`) — ~13 resources: the BYO 3 plus an `aws_eks_cluster`, `aws_eks_node_group`, two `aws_iam_role`s for the cluster and node, and five `aws_iam_role_policy_attachment`s. Apply takes ~15-20 minutes (most of it waiting for the EKS control plane to come up).
+
+## Verify
+
+1. Helm release is healthy:
+   ```bash
+   helm status -n $(terraform output -raw namespace) $(terraform output -raw helm_release_name)
+   kubectl -n $(terraform output -raw namespace) get pods
+   ```
+2. The cluster check is dispatched. From the Cluster Agent:
+   ```bash
+   kubectl -n $(terraform output -raw namespace) exec -it \
+     deploy/$(terraform output -raw cluster_agent_deployment) -- \
+     agent clusterchecks
+   ```
+   Look for a `mysql` entry assigned to one of the cluster-check runner pods.
+3. Tail the runner logs and look for the `[mysql]` check running cleanly:
+   ```bash
+   kubectl -n $(terraform output -raw namespace) logs -l app=$(terraform output -raw cluster_check_runner_deployment) -f
+   ```
+   You should see lines like `Running check mysql` and no `performance_schema` errors.
+4. In the Datadog UI:
+   - **Infrastructure → Kubernetes**: the EKS cluster appears with node and pod metrics.
+   - **Databases → List**: the MySQL host appears with DBM enabled.
+   - **Databases → Query Metrics**: rows render within ~2 minutes of database traffic.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+What gets removed depends on the mode:
+
+- **BYO mode** — removes the helm release, the namespace, and the ingress rule we added to the database's SG. **The EKS cluster, the worker nodes, the database, and the MySQL `datadog` user are untouched.** This is the BYO assertion: dropping our Terraform onto your existing cluster will not nuke it on destroy.
+- **Greenfield mode** — removes everything: helm release, namespace, database SG ingress rule, EKS node group, EKS cluster, and the IAM roles + policy attachments this template created. **The database and the MySQL `datadog` user are still untouched.** Stops the ~$0.10/hr control-plane charge once destroy completes (typically ~10 minutes).
+
+## Security note
+
+Both `datadog_user_password` and `datadog_api_key` are passed straight into the helm release values, but they land in different Kubernetes objects:
+
+- **`datadog_api_key`** — rendered into a Kubernetes **Secret** by the chart. Readable by anyone with `get secret` in the release namespace.
+- **`datadog_user_password`** — embedded in the MySQL check yaml under `clusterAgent.confd` and rendered into a Kubernetes **ConfigMap**. Readable by anyone with `get configmap` in the release namespace.
+
+This is fine for a demo; for production:
+
+1. Store both in **AWS Secrets Manager** (or another secret store).
+2. Use the External Secrets Operator (or the chart's `apiKeyExistingSecret` / `secretBackend` settings) to project them into the agent at runtime.
+3. Reference the password in the MySQL check via `password = "ENC[...]"` with a configured secret backend, or via `${ENV_VAR}` after wiring the env var into the cluster-check runner pod spec.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Cluster-check runner logs show `connection refused` to the database | Database SG ingress rule didn't apply, or runner pods are on nodes whose SG is not `eks_node_security_group_id` |
+| Runner logs show `performance_schema is disabled` | Parameter group missing `performance_schema=1`, or RDS not rebooted |
+| Runner logs show `Access denied for user 'datadog'` | Manual SQL not run, or grants missing |
+| `query_metrics` empty but check is running | `events_statements_*` consumers not enabled in `performance_schema.setup_consumers` |
+| `query_samples` empty | `datadog.explain_statement` procedure not created, or `EXECUTE` not granted on `datadog.*` |
+| `agent clusterchecks` on the Cluster Agent shows the mysql check as unscheduled | `clusterChecksRunner.enabled` was disabled, or the runner deployment has zero ready pods |
+| No data in Datadog UI | API key wrong, `DD_SITE` mismatched, or pods can't reach `*.${DD_SITE}` (NAT egress / VPC endpoint missing) |
+| `terraform plan` fails reading the EKS cluster | IAM principal running Terraform lacks `eks:DescribeCluster` / `eks:GetToken`, or is not mapped in `aws-auth` / EKS access entries for the cluster |
+
+## Files
+
+- `versions.tf` — Terraform + provider pins, EKS-backed `helm`/`kubernetes` provider config
+- `variables.tf` — inputs (secrets marked `sensitive`)
+- `main.tf` — namespace, helm release (Agent + Cluster Agent + CLC runners + MySQL cluster check), database-side ingress rule
+- `outputs.tf` — useful identifiers for verification
+- `terraform.tfvars.example` — fill-in-the-blanks template

--- a/terraform/mysql/aws/amazon-eks/main.tf
+++ b/terraform/mysql/aws/amazon-eks/main.tf
@@ -1,0 +1,263 @@
+locals {
+  # Greenfield mode when no existing cluster name is supplied.
+  manage_cluster = var.eks_cluster_name == ""
+
+  # Resolved cluster name — either the BYO name or the freshly-created one.
+  cluster_name = local.manage_cluster ? aws_eks_cluster.main[0].name : var.eks_cluster_name
+
+  # Source SG for the database's ingress rule. In greenfield mode we use the
+  # cluster's auto-created cluster security group, which the managed node group
+  # attaches to every node by default. In BYO mode the customer supplies it.
+  node_security_group_id = local.manage_cluster ? aws_eks_cluster.main[0].vpc_config[0].cluster_security_group_id : var.eks_node_security_group_id
+}
+
+# ---------------------------------------------------------------------------
+# Greenfield path: provision a new EKS cluster + managed node group.
+# Skipped entirely when eks_cluster_name is set (BYO).
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "cluster" {
+  count = local.manage_cluster ? 1 : 0
+  name  = "${var.name_prefix}-cluster-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "eks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_amazoneks" {
+  count      = local.manage_cluster ? 1 : 0
+  role       = aws_iam_role.cluster[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_vpc_resource_controller" {
+  count      = local.manage_cluster ? 1 : 0
+  role       = aws_iam_role.cluster[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+}
+
+resource "aws_eks_cluster" "main" {
+  count    = local.manage_cluster ? 1 : 0
+  name     = "${var.name_prefix}-cluster"
+  role_arn = aws_iam_role.cluster[0].arn
+  version  = var.kubernetes_version
+
+  vpc_config {
+    subnet_ids              = var.private_subnet_ids
+    endpoint_public_access  = true
+    endpoint_private_access = true
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_amazoneks,
+    aws_iam_role_policy_attachment.cluster_vpc_resource_controller,
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = length(var.private_subnet_ids) >= 2
+      error_message = "private_subnet_ids must contain at least 2 subnets (in different AZs) when provisioning a new EKS cluster (eks_cluster_name empty)."
+    }
+  }
+}
+
+resource "aws_iam_role" "node" {
+  count = local.manage_cluster ? 1 : 0
+  name  = "${var.name_prefix}-node-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker" {
+  count      = local.manage_cluster ? 1 : 0
+  role       = aws_iam_role.node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni" {
+  count      = local.manage_cluster ? 1 : 0
+  role       = aws_iam_role.node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_ecr" {
+  count      = local.manage_cluster ? 1 : 0
+  role       = aws_iam_role.node[0].name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_node_group" "main" {
+  count           = local.manage_cluster ? 1 : 0
+  cluster_name    = aws_eks_cluster.main[0].name
+  node_group_name = "${var.name_prefix}-nodes"
+  node_role_arn   = aws_iam_role.node[0].arn
+  subnet_ids      = var.private_subnet_ids
+  instance_types  = [var.node_instance_type]
+  disk_size       = var.node_disk_size_gb
+
+  scaling_config {
+    desired_size = var.node_desired_count
+    min_size     = var.node_min_count
+    max_size     = var.node_max_count
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_worker,
+    aws_iam_role_policy_attachment.node_cni,
+    aws_iam_role_policy_attachment.node_ecr,
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Always-on path: agent install + database SG ingress rule. Identical for both
+# BYO and greenfield modes; just sources its inputs from the locals above.
+# ---------------------------------------------------------------------------
+
+# Open MySQL ingress on the database's security group from the EKS node SG.
+# Managed as a standalone rule so the database's SG itself stays untouched apart
+# from this single addition (and is cleanly removed on terraform destroy).
+resource "aws_security_group_rule" "db_ingress_from_eks_nodes" {
+  type                     = "ingress"
+  description              = "Datadog Agent (EKS) cluster-check runners to MySQL"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  security_group_id        = var.db_security_group_id
+  source_security_group_id = local.node_security_group_id
+
+  lifecycle {
+    precondition {
+      condition     = (var.eks_cluster_name == "") == (var.eks_node_security_group_id == "")
+      error_message = "eks_cluster_name and eks_node_security_group_id must both be set (BYO mode) or both empty (greenfield mode)."
+    }
+  }
+}
+
+resource "kubernetes_namespace" "datadog" {
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/name"       = "datadog-agent"
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+# Helm release: deploys the node Agent DaemonSet, the Cluster Agent, and the
+# Cluster Check Runner Deployment. The MySQL check runs as a cluster check
+# (single-instance, dispatched by the Cluster Agent to a CLC runner pod) — the
+# right pattern for monitoring an external resource like a managed MySQL,
+# so that DBM data isn't duplicated by every node in the cluster.
+resource "helm_release" "datadog" {
+  # Keep the release name short — the datadog/datadog chart appends suffixes
+  # up to 43 chars (e.g. -datadog-cluster-agent-admission-controller) onto the
+  # release name to derive Kubernetes service names. K8s service names are
+  # capped at 63 chars (DNS-1123), so the release name must be <= 20 chars.
+  name       = var.name_prefix
+  namespace  = kubernetes_namespace.datadog.metadata[0].name
+  repository = "https://helm.datadoghq.com"
+  chart      = "datadog"
+  version    = var.datadog_helm_chart_version
+
+  values = [
+    yamlencode({
+      datadog = {
+        apiKey      = var.datadog_api_key
+        appKey      = var.datadog_app_key
+        site        = var.datadog_site
+        clusterName = local.cluster_name
+        tags        = var.agent_host_tags
+
+        clusterChecks = {
+          enabled = true
+        }
+      }
+
+      agents = {
+        image = {
+          tag = var.agent_image_tag
+        }
+      }
+
+      # Cluster Agent. Image tag is intentionally omitted so the helm chart's
+      # pinned cluster-agent version takes effect — Datadog publishes the
+      # cluster-agent only with specific version tags (7.55.0, 7.56.0, ...),
+      # NOT with a "7" major-version shortcut like the main agent has.
+      #
+      # The MySQL check is placed in `clusterAgent.confd` (NOT `datadog.confd`)
+      # so the Cluster Agent reads it directly and dispatches it to a CLC runner.
+      # Putting it under `datadog.confd` would route it through node-agent
+      # autodiscovery, which the chart does not propagate to the cluster agent
+      # for cluster-check dispatch — the check would be configured on the
+      # DaemonSet pods but never actually scheduled.
+      clusterAgent = {
+        enabled  = true
+        replicas = 2
+        confd = {
+          "mysql.yaml" = yamlencode({
+            cluster_check = true
+            init_config   = {}
+            instances = [
+              {
+                dbm      = true
+                host     = var.db_endpoint
+                port     = var.db_port
+                username = var.datadog_user
+                password = var.datadog_user_password
+                options = {
+                  replication          = var.replication_enabled
+                  extra_status_metrics = true
+                  extra_innodb_metrics = true
+                  schemas_collection = {
+                    enabled = var.schemas_collection_enabled
+                  }
+                }
+                query_metrics = {
+                  enabled             = true
+                  collection_interval = 10
+                }
+                query_samples = {
+                  enabled             = true
+                  collection_interval = 1
+                }
+                query_activity = {
+                  enabled             = true
+                  collection_interval = 10
+                }
+                tags = var.agent_host_tags
+              }
+            ]
+          })
+        }
+      }
+
+      # Dedicated Cluster Check Runner Deployment. The MySQL cluster check
+      # runs in these pods rather than on a node Agent, so database connectivity
+      # is only required from this set of pods.
+      clusterChecksRunner = {
+        enabled  = true
+        replicas = var.cluster_check_runners_replicas
+      }
+    })
+  ]
+
+  # In greenfield mode, the helm release must wait for the node group to be
+  # ready (otherwise pods stay Pending). In BYO mode the node group already
+  # exists; the [0] indexing into a length-0 list is fine because aws_eks_node_group
+  # has count=0 and Terraform handles that gracefully.
+  depends_on = [
+    aws_security_group_rule.db_ingress_from_eks_nodes,
+    aws_eks_node_group.main,
+  ]
+}

--- a/terraform/mysql/aws/amazon-eks/outputs.tf
+++ b/terraform/mysql/aws/amazon-eks/outputs.tf
@@ -1,0 +1,39 @@
+output "eks_cluster_name" {
+  description = "EKS cluster name. The newly-created one in greenfield mode, or the existing BYO cluster name."
+  value       = local.cluster_name
+}
+
+output "eks_cluster_endpoint" {
+  description = "EKS API endpoint. Use with kubectl: aws eks update-kubeconfig --name $(terraform output -raw eks_cluster_name) --region <region>."
+  value       = data.aws_eks_cluster.this.endpoint
+}
+
+output "eks_node_security_group_id" {
+  description = "Security group ID attached to EKS worker nodes. Resolved from greenfield (auto-created cluster SG) or BYO (customer-supplied)."
+  value       = local.node_security_group_id
+}
+
+output "namespace" {
+  description = "Kubernetes namespace where the Datadog Agent helm release is installed."
+  value       = kubernetes_namespace.datadog.metadata[0].name
+}
+
+output "helm_release_name" {
+  description = "Helm release name (use with `helm status -n <namespace>`)."
+  value       = helm_release.datadog.name
+}
+
+output "cluster_check_runner_deployment" {
+  description = "Deployment name of the Cluster Check Runner pods that execute the MySQL check."
+  value       = "${helm_release.datadog.name}-datadog-clusterchecks"
+}
+
+output "cluster_agent_deployment" {
+  description = "Deployment name of the Datadog Cluster Agent."
+  value       = "${helm_release.datadog.name}-datadog-cluster-agent"
+}
+
+output "db_ingress_rule_id" {
+  description = "ID of the security-group ingress rule added to the MySQL database's SG."
+  value       = aws_security_group_rule.db_ingress_from_eks_nodes.id
+}

--- a/terraform/mysql/aws/amazon-eks/terraform.tfvars.example
+++ b/terraform/mysql/aws/amazon-eks/terraform.tfvars.example
@@ -1,0 +1,56 @@
+aws_region = "us-east-1"
+
+# ------------------------------------------------------------------
+# Pick ONE of the two paths below.
+# ------------------------------------------------------------------
+
+# === Path A: bring your own EKS cluster ===
+# Set both. The template skips cluster + node group creation and only
+# installs the Datadog Agent helm release into the supplied cluster.
+eks_cluster_name           = "my-eks-cluster"
+eks_node_security_group_id = "sg-0eksnodes000000000"
+
+# === Path B: provision a new EKS cluster ===
+# Comment out the two lines above and uncomment the block below. The
+# template provisions an EKS cluster + managed node group, then installs
+# the agent. Adds ~$0.10/hr for the EKS control plane and ~15min to apply
+# time. The auto-created cluster security group is used as the source for
+# the database's ingress rule.
+#
+# private_subnet_ids = [
+#   "subnet-aaaaaaaaaaaaaaaaa",   # AZ-a, must have NAT egress
+#   "subnet-bbbbbbbbbbbbbbbbb",   # AZ-b, must have NAT egress
+# ]
+# kubernetes_version = "1.30"
+# node_instance_type = "t3.small"
+# node_desired_count = 2
+# node_min_count     = 2
+# node_max_count     = 4
+# node_disk_size_gb  = 20
+
+# ------------------------------------------------------------------
+# Inputs that apply to both paths
+# ------------------------------------------------------------------
+
+# MySQL database security group — RDS instance SG, Aurora cluster SG,
+# or the EC2 instance's SG for self-hosted MySQL.
+db_security_group_id = "sg-0mysqldb000000000"
+
+# MySQL connection details.
+# db_endpoint:
+#   - RDS:                the RDS endpoint
+#   - Aurora:             the cluster writer endpoint
+#   - self-hosted on EC2: the instance hostname or IP
+db_endpoint = "my-db.cluster-xxxxxxxxxxxx.us-east-1.rds.amazonaws.com"
+db_port     = 3306
+
+# Datadog MySQL user -- already created on the DB (see README §Manual SQL).
+datadog_user          = "datadog"
+datadog_user_password = "REPLACE_ME"
+
+# Datadog destination.
+datadog_api_key = "REPLACE_ME"
+datadog_app_key = ""
+datadog_site    = "datadoghq.com"
+
+agent_host_tags = ["env:demo", "team:dbm", "service:mysql-eks-demo"]

--- a/terraform/mysql/aws/amazon-eks/variables.tf
+++ b/terraform/mysql/aws/amazon-eks/variables.tf
@@ -1,0 +1,163 @@
+variable "aws_region" {
+  description = "AWS region of the EKS cluster and the MySQL database."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix used for k8s namespace, helm release, and AWS-side resource names. Capped at 20 characters because the datadog/datadog Helm chart appends suffixes up to 43 chars onto the release name (e.g. -datadog-cluster-agent-admission-controller), and Kubernetes service names are capped at 63 chars (DNS-1123)."
+  type        = string
+  default     = "dbm-mysql-eks"
+
+  validation {
+    condition     = length(var.name_prefix) <= 20
+    error_message = "name_prefix must be at most 20 characters (the datadog Helm chart's longest service name suffix is 43 chars, leaving 20 for the release name to fit under the 63-char K8s service name limit)."
+  }
+}
+
+variable "eks_cluster_name" {
+  description = "Name of an existing EKS cluster to install the Datadog Agent into. Leave empty (default) to provision a new EKS cluster + managed node group named \"${name_prefix}-cluster\". When set, eks_node_security_group_id must also be set."
+  type        = string
+  default     = ""
+}
+
+variable "eks_node_security_group_id" {
+  description = "Security group attached to the EKS worker nodes when bringing your own cluster (eks_cluster_name set). An ingress rule on the database SG is added from this SG so the cluster-check runner pods can reach MySQL. Ignored when provisioning a new cluster (the auto-created cluster security group is used instead)."
+  type        = string
+  default     = ""
+}
+
+# ---------------------------------------------------------------------------
+# Inputs used ONLY when provisioning a new EKS cluster
+# (eks_cluster_name = "")
+# ---------------------------------------------------------------------------
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs (>= 2 in different AZs) for the EKS control plane ENIs and the managed node group. Required when provisioning a new cluster; ignored when bringing your own. Subnets must have NAT egress so the agent + nodes can reach Datadog and pull container images."
+  type        = list(string)
+  default     = []
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the new EKS cluster. Ignored when bringing your own."
+  type        = string
+  default     = "1.30"
+}
+
+variable "node_instance_type" {
+  description = "EC2 instance type for the managed node group. Ignored when bringing your own."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "node_desired_count" {
+  description = "Desired node count for the managed node group. Ignored when bringing your own."
+  type        = number
+  default     = 2
+}
+
+variable "node_min_count" {
+  description = "Minimum node count for the managed node group. Ignored when bringing your own."
+  type        = number
+  default     = 2
+}
+
+variable "node_max_count" {
+  description = "Maximum node count for the managed node group. Ignored when bringing your own."
+  type        = number
+  default     = 4
+}
+
+variable "node_disk_size_gb" {
+  description = "Root EBS volume size for managed node group instances (GiB). Ignored when bringing your own."
+  type        = number
+  default     = 20
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace for the Datadog Agent helm release. Created if it does not already exist."
+  type        = string
+  default     = "datadog"
+}
+
+variable "db_security_group_id" {
+  description = "Security group attached to your MySQL database (RDS instance SG, Aurora cluster SG, or EC2 instance SG for self-hosted). An ingress rule on port 3306 from the EKS node SG is added to it."
+  type        = string
+}
+
+variable "db_endpoint" {
+  description = "MySQL endpoint hostname (no port). For RDS, the RDS endpoint; for Aurora, the cluster writer endpoint; for self-hosted on EC2, the instance hostname or IP."
+  type        = string
+}
+
+variable "db_port" {
+  description = "MySQL TCP port."
+  type        = number
+  default     = 3306
+}
+
+variable "datadog_user" {
+  description = "MySQL user the Agent connects as. Must already exist (created out-of-band -- see README)."
+  type        = string
+  default     = "datadog"
+}
+
+variable "datadog_user_password" {
+  description = "Password for the datadog MySQL user. Lands in the helm release values (and therefore in a kube ConfigMap) -- see README security note."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key for the destination org."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_app_key" {
+  description = "Datadog application key. Required by the Cluster Agent for some features (events, external metrics). Optional for plain DBM."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "datadog_site" {
+  description = "Datadog site (datadoghq.com, datadoghq.eu, us3.datadoghq.com, etc.)."
+  type        = string
+  default     = "datadoghq.com"
+}
+
+variable "datadog_helm_chart_version" {
+  description = "Version of the datadog/datadog Helm chart. Pin for reproducibility."
+  type        = string
+  default     = "3.74.0"
+}
+
+variable "agent_image_tag" {
+  description = "Datadog Agent container image tag used by the helm release. The default \"7\" floats to the latest 7.x release; for reproducible deploys pin to a specific tag like \"7.58.2\"."
+  type        = string
+  default     = "7"
+}
+
+variable "cluster_check_runners_replicas" {
+  description = "Number of dedicated Cluster Check Runner pods. The MySQL check is dispatched to these pods so it runs once cluster-wide rather than per node."
+  type        = number
+  default     = 2
+}
+
+variable "replication_enabled" {
+  description = "Set true if the monitored MySQL is a replica and you want replication metrics. Requires REPLICATION CLIENT grants on the datadog user (already covered in the manual SQL)."
+  type        = bool
+  default     = false
+}
+
+variable "schemas_collection_enabled" {
+  description = "Enable MySQL schemas collection (table/column/index metadata)."
+  type        = bool
+  default     = true
+}
+
+variable "agent_host_tags" {
+  description = "Tags applied to the MySQL instance via the check config (env, team, etc.)."
+  type        = list(string)
+  default     = ["env:demo", "team:dbm"]
+}

--- a/terraform/mysql/aws/amazon-eks/versions.tf
+++ b/terraform/mysql/aws/amazon-eks/versions.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.12"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.27"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Pull EKS cluster details so the helm/kubernetes providers can authenticate
+# without depending on a local kubeconfig. Works for both paths:
+#   - BYO  → reads the existing cluster (eks_cluster_name set)
+#   - new  → reads the cluster created by aws_eks_cluster.main (depends_on
+#            ensures the data source refreshes after the cluster is up)
+data "aws_eks_cluster" "this" {
+  name       = local.cluster_name
+  depends_on = [aws_eks_cluster.main]
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name       = local.cluster_name
+  depends_on = [aws_eks_cluster.main]
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}

--- a/terraform/mysql/aws/ec2/.gitignore
+++ b/terraform/mysql/aws/ec2/.gitignore
@@ -1,0 +1,16 @@
+# Sensitive credentials -- never commit these
+*.tfvars
+!*.tfvars.example
+
+# Terraform state (contains sensitive data)
+*.tfstate
+*.tfstate.*
+.terraform/
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/terraform/mysql/aws/ec2/README.md
+++ b/terraform/mysql/aws/ec2/README.md
@@ -1,0 +1,167 @@
+# DBM on EC2 -- MySQL in AWS
+
+Stands up a single Datadog Agent on an **AWS EC2** instance with **Database Monitoring** enabled, configured to monitor an **existing MySQL database in AWS**.
+
+This is a bring-your-own-DB setup: it does **not** provision the database, a VPC, or the MySQL `datadog` user. It only deploys the agent into the VPC where your MySQL already lives, and opens the right ingress on the database's security group.
+
+Companion to the Postgres EC2 sibling ([`../../postgres/../ec2/`](../../postgres/aws/ec2/)) -- different database, same agent runtime.
+
+## Hosting coverage
+
+This module works for any MySQL database reachable inside an AWS VPC by security group. Point `db_endpoint` and `db_security_group_id` at:
+
+- **Amazon RDS MySQL** -- the RDS endpoint and the RDS security group.
+- **Amazon Aurora MySQL** -- the Aurora cluster writer endpoint and the Aurora cluster's security group.
+- **Self-hosted MySQL on EC2 in the same VPC** -- the EC2 instance hostname/IP and the security group attached to the MySQL EC2 instance.
+
+For MySQL self-hosted **outside AWS** (on-premises, in another cloud), this AWS-side example does not apply.
+
+## Architecture
+
+```
+   ┌────────────────────── existing VPC ──────────────────────┐
+   │                                                          │
+   │   chosen subnet (public for SSH, or private + SSM)       │
+   │   ┌────────────────────────┐    3306    ┌──────────────┐ │
+   │   │  EC2 (Amazon Linux 23) │ ─────────▶ │    MySQL     │ │
+   │   │  docker run            │            │  (RDS, or    │ │
+   │   │  datadog/agent:7       │            │   Aurora, or │ │
+   │   │  mysql.d/conf.yaml     │            │   self-      │ │
+   │   └─────────┬──────────────┘            │   hosted EC2)│ │
+   │             │ outbound                  └──────────────┘ │
+   └─────────────┼──────────────────────────────────────────-─┘
+                 ▼
+            Datadog (DD_SITE)
+```
+
+## Prerequisites
+
+- **Terraform >= 1.5** and AWS credentials with permission to create EC2, IAM, and security groups in the target region.
+- **An existing MySQL database** (MySQL 5.7+ or 8.0+) -- RDS, Aurora, or self-hosted on EC2.
+- **A subnet in the database's VPC** with internet egress (IGW for a public subnet, NAT for a private one) so the agent can reach `*.${DD_SITE}` and pull the agent image.
+- **RDS parameter group** (or `my.cnf` for self-hosted) with the following parameters set (Performance Schema is the source of truth for DBM):
+
+  | Parameter | Value | Why |
+  |---|---|---|
+  | `performance_schema` | `1` | Required for query metrics, samples, and activity |
+  | `max_digest_length` | `4096` | Larger captured SQL text |
+  | `performance_schema_max_digest_length` | `4096` | Match `max_digest_length` |
+  | `performance_schema_max_sql_text_length` | `4096` | Larger captured SQL text |
+
+  Changing `performance_schema` requires an RDS reboot.
+
+- **The MySQL `datadog` user** created on the database -- see *Manual SQL* below.
+- A **Datadog API key** for the destination org.
+- (Optional) An existing **EC2 key pair** if you want SSH access -- otherwise leave `key_pair_name = ""` and use SSM Session Manager.
+
+## Manual SQL
+
+Run this once against the MySQL instance using the master user.
+
+```sql
+-- Create the user
+CREATE USER datadog@'%' IDENTIFIED BY '<PASSWORD>';
+ALTER USER datadog@'%' WITH MAX_USER_CONNECTIONS 5;
+
+-- Required for monitoring
+GRANT REPLICATION CLIENT ON *.* TO datadog@'%';
+GRANT PROCESS ON *.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
+
+-- Required for DBM (host metadata + explain plan capture)
+GRANT SELECT ON mysql.user TO datadog@'%';
+
+CREATE SCHEMA IF NOT EXISTS datadog;
+GRANT EXECUTE ON datadog.* TO datadog@'%';
+GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
+
+DELIMITER $$
+CREATE PROCEDURE datadog.explain_statement(IN query TEXT)
+    SQL SECURITY DEFINER
+BEGIN
+    SET @explain := CONCAT('EXPLAIN FORMAT=json ', query);
+    PREPARE stmt FROM @explain;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+END $$
+DELIMITER ;
+
+-- Performance Schema consumers (run as master user, not as datadog)
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
+```
+
+Reference: [Setup DBM for MySQL managed by AWS](https://docs.datadoghq.com/database_monitoring/setup_mysql/rds/).
+
+## Apply
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# fill in vpc_id, subnet_id, db_security_group_id, db_endpoint,
+# datadog_user_password, datadog_api_key, and any optional overrides
+
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform apply` creates ~7 resources: EC2 instance, host security group, database-side ingress rule, IAM role + SSM policy attachment + instance profile.
+
+## Verify
+
+1. Instance is running:
+   ```bash
+   aws ec2 describe-instances --instance-ids $(terraform output -raw ec2_instance_id) \
+     --query 'Reservations[0].Instances[0].{state:State.Name,ip:PublicIpAddress}'
+   ```
+2. Reach the host (use whichever path matches your config):
+   ```bash
+   # SSH (assign_public_ip=true and key_pair_name set)
+   $(terraform output -raw ec2_ssh_command)
+
+   # SSM (any subnet, no SSH needed)
+   aws ssm start-session --target $(terraform output -raw ec2_instance_id)
+   ```
+3. Check the agent container is healthy:
+   ```bash
+   docker ps
+   docker logs datadog-agent | grep -E '(mysql|dbm)' | tail -50
+   ```
+   You should see `Running check mysql` and no `performance_schema` errors.
+4. In the Datadog UI:
+   - **Infrastructure --> Hosts**: the EC2 host appears.
+   - **Databases --> List**: the MySQL host appears with DBM enabled.
+   - **Databases --> Query Metrics**: rows render within ~2 minutes of database traffic.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+Removes the EC2 instance, host SG, IAM role, and the ingress rule added to the database SG. The MySQL instance, VPC, and the `datadog` user are untouched.
+
+## Security note
+
+The `datadog_user_password` is rendered into `/etc/datadog-agent/conf.d/mysql.d/conf.yaml` on the host via `user_data` (cloud-init). EC2 user_data is readable by anyone with `ec2:DescribeInstanceAttribute` on the instance, and the rendered file is readable by anyone with shell access. This is fine for a demo; for production, switch to **AWS Secrets Manager** + a small fetch script in `user_data`, or move to ECS Fargate with `secrets[]`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Agent logs show `connection refused` to database | Database SG ingress rule didn't apply, or instance is in a subnet with no route to the database |
+| Agent logs show `performance_schema is disabled` | Parameter group missing `performance_schema=1`, or RDS not rebooted after the change |
+| Agent logs show `Access denied for user 'datadog'` | Manual SQL not run, or grants missing |
+| `query_metrics` empty but check is running | `events_statements_*` consumers not enabled in `performance_schema.setup_consumers` |
+| `query_samples` empty | `datadog.explain_statement` procedure not created, or `EXECUTE` not granted on `datadog.*` |
+| No data in Datadog UI | API key wrong, `DD_SITE` mismatched, or instance can't reach `*.${DD_SITE}` (no IGW/NAT egress) |
+| `docker: command not found` on first SSH | `user_data` still running -- wait ~60s and re-check with `cloud-init status --wait` |
+
+## Files
+
+- `versions.tf` -- Terraform + provider pins
+- `variables.tf` -- inputs (secrets marked `sensitive`)
+- `main.tf` -- EC2 instance, IAM role, security group, database ingress rule
+- `user_data.sh.tpl` -- cloud-init script: installs Docker, drops conf.yaml, runs the agent
+- `outputs.tf` -- useful identifiers for verification
+- `terraform.tfvars.example` -- fill-in-the-blanks template

--- a/terraform/mysql/aws/ec2/main.tf
+++ b/terraform/mysql/aws/ec2/main.tf
@@ -1,0 +1,160 @@
+# Latest Amazon Linux 2023 AMI in the target region.
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023*-x86_64"]
+  }
+
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+}
+
+# Pre-render the MySQL integration config as YAML so the user_data heredoc
+# just emits a literal value. yamlencode handles all escaping, so passwords or
+# tag values containing ":", "#", quotes, or newlines round-trip safely.
+locals {
+  mysql_check_yaml = yamlencode({
+    init_config = {}
+    instances = [{
+      dbm      = true
+      host     = var.db_endpoint
+      port     = var.db_port
+      username = var.datadog_user
+      password = var.datadog_user_password
+      options = {
+        replication          = var.replication_enabled
+        extra_status_metrics = true
+        extra_innodb_metrics = true
+        schemas_collection = {
+          enabled = var.schemas_collection_enabled
+        }
+      }
+      query_metrics = {
+        enabled             = true
+        collection_interval = 10
+      }
+      query_samples = {
+        enabled             = true
+        collection_interval = 1
+      }
+      query_activity = {
+        enabled             = true
+        collection_interval = 10
+      }
+      tags = var.agent_host_tags
+    }]
+  })
+}
+
+# Security group for the EC2 instance. SSH ingress is opt-in (only added if
+# ssh_ingress_cidrs is non-empty); egress is wide open so the agent can pull
+# the image, reach Datadog, and reach the database.
+resource "aws_security_group" "agent_host" {
+  name        = "${var.name_prefix}-host-sg"
+  description = "Datadog Agent EC2 host - SSH inbound from allowed IPs, all outbound"
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.ssh_ingress_cidrs
+    content {
+      description = "SSH from ${ingress.value}"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = [ingress.value]
+    }
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name_prefix}-host-sg" }
+}
+
+# Open MySQL ingress on the database's security group from the EC2 host SG.
+# Managed as a standalone rule so the database's SG itself stays untouched apart
+# from this single addition (and is cleanly removed on terraform destroy).
+resource "aws_security_group_rule" "db_ingress_from_agent" {
+  type                     = "ingress"
+  description              = "Datadog Agent EC2 host to MySQL"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  security_group_id        = var.db_security_group_id
+  source_security_group_id = aws_security_group.agent_host.id
+}
+
+# Instance profile -- only used so SSM Session Manager works out of the box
+# (handy when assign_public_ip = false and there is no SSH path).
+resource "aws_iam_role" "ec2" {
+  name = "${var.name_prefix}-ec2-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${var.name_prefix}-ec2-profile"
+  role = aws_iam_role.ec2.name
+}
+
+# Single EC2 host running the Datadog Agent in Docker. The MySQL check is
+# configured via a conf.yaml dropped into /etc/datadog-agent/conf.d/mysql.d
+# and bind-mounted into the container.
+resource "aws_instance" "agent" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = var.instance_type
+  subnet_id                   = var.subnet_id
+  vpc_security_group_ids      = [aws_security_group.agent_host.id]
+  iam_instance_profile        = aws_iam_instance_profile.ec2.name
+  associate_public_ip_address = var.assign_public_ip
+  key_name                    = var.key_pair_name != "" ? var.key_pair_name : null
+
+  user_data = templatefile("${path.module}/user_data.sh.tpl", {
+    mysql_check_yaml = local.mysql_check_yaml
+    datadog_api_key  = var.datadog_api_key
+    datadog_site     = var.datadog_site
+    agent_image      = var.agent_image
+  })
+
+  user_data_replace_on_change = true
+
+  metadata_options {
+    http_tokens = "required"
+    # Bridge-networked Docker (the default for `docker run` without --network host)
+    # adds one network hop, which drops the IMDSv2 token's TTL to 0 by the time
+    # the response reaches the container. Setting hop_limit=2 keeps IMDS reachable
+    # so the Agent can pick up EC2 metadata + AWS host tags.
+    http_put_response_hop_limit = 2
+  }
+
+  root_block_device {
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  tags = { Name = "${var.name_prefix}-agent" }
+}

--- a/terraform/mysql/aws/ec2/outputs.tf
+++ b/terraform/mysql/aws/ec2/outputs.tf
@@ -1,0 +1,24 @@
+output "ec2_instance_id" {
+  description = "EC2 instance running the Datadog Agent."
+  value       = aws_instance.agent.id
+}
+
+output "ec2_public_ip" {
+  description = "Public IP of the EC2 instance (only populated when assign_public_ip = true)."
+  value       = aws_instance.agent.public_ip
+}
+
+output "ec2_private_ip" {
+  description = "Private IP of the EC2 instance."
+  value       = aws_instance.agent.private_ip
+}
+
+output "ec2_ssh_command" {
+  description = "Convenience SSH command (requires assign_public_ip = true and a key_pair_name)."
+  value       = var.assign_public_ip && var.key_pair_name != "" ? "ssh -i ~/.ssh/${var.key_pair_name}.pem ec2-user@${aws_instance.agent.public_ip}" : "n/a -- set assign_public_ip and key_pair_name to enable, or use SSM: aws ssm start-session --target ${aws_instance.agent.id}"
+}
+
+output "agent_host_security_group_id" {
+  description = "Security group attached to the EC2 host."
+  value       = aws_security_group.agent_host.id
+}

--- a/terraform/mysql/aws/ec2/terraform.tfvars.example
+++ b/terraform/mysql/aws/ec2/terraform.tfvars.example
@@ -1,0 +1,27 @@
+aws_region = "us-east-1"
+
+# Existing database networking -- fill in from your AWS console or `aws rds describe-db-instances`.
+vpc_id               = "vpc-0123456789abcdef0"
+subnet_id            = "subnet-aaaaaaaaaaaaaaaaa"
+db_security_group_id = "sg-0123456789abcdef0"
+
+# Public-subnet demo posture. Set assign_public_ip = false (and provide a
+# private subnet above) to run the agent in a private subnet -- verify via SSM
+# Session Manager instead of SSH.
+assign_public_ip  = true
+key_pair_name     = "my-keypair"
+ssh_ingress_cidrs = ["203.0.113.42/32"]
+
+# MySQL connection details.
+db_endpoint = "my-db.cluster-xxxxxxxxxxxx.us-east-1.rds.amazonaws.com"
+db_port     = 3306
+
+# Datadog MySQL user -- already created on the DB (see README §Manual SQL).
+datadog_user          = "datadog"
+datadog_user_password = "REPLACE_ME"
+
+# Datadog destination.
+datadog_api_key = "REPLACE_ME"
+datadog_site    = "datadoghq.com"
+
+agent_host_tags = ["env:demo", "team:dbm", "service:mysql-ec2-demo"]

--- a/terraform/mysql/aws/ec2/user_data.sh.tpl
+++ b/terraform/mysql/aws/ec2/user_data.sh.tpl
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install Docker (Amazon Linux 2023).
+dnf install -y docker
+systemctl enable docker
+systemctl start docker
+
+# Allow ec2-user to run docker without sudo (matches the unprivileged
+# `docker ps` / `docker logs datadog-agent` commands shown in the README).
+# Takes effect on the next login session.
+usermod -aG docker ec2-user
+
+# Drop the MySQL integration config where the agent container will mount it.
+# mysql_check_yaml is rendered by Terraform via yamlencode so any special
+# characters in the password, tags, or other inputs are properly escaped.
+mkdir -p /etc/datadog-agent/conf.d/mysql.d
+cat > /etc/datadog-agent/conf.d/mysql.d/conf.yaml <<'YAML'
+${mysql_check_yaml}
+YAML
+
+# Run the agent container, mounting only the mysql.d directory so the
+# integration picks up our config.
+docker run -d \
+  --name datadog-agent \
+  --restart unless-stopped \
+  -e DD_API_KEY=${datadog_api_key} \
+  -e DD_SITE=${datadog_site} \
+  -e DD_HOSTNAME=$(hostname -s) \
+  -v /etc/datadog-agent/conf.d/mysql.d:/etc/datadog-agent/conf.d/mysql.d:ro \
+  ${agent_image}

--- a/terraform/mysql/aws/ec2/variables.tf
+++ b/terraform/mysql/aws/ec2/variables.tf
@@ -1,0 +1,114 @@
+variable "aws_region" {
+  description = "AWS region where the EC2 instance runs. Should match the database's region."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix used for all resource names."
+  type        = string
+  default     = "dbm-mysql-ec2"
+}
+
+variable "vpc_id" {
+  description = "VPC where the MySQL database lives. The EC2 instance is launched in this same VPC."
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the EC2 instance. Must route to the database and to the internet (for pulling the agent image and reaching Datadog)."
+  type        = string
+}
+
+variable "assign_public_ip" {
+  description = "Whether to assign a public IP to the EC2 instance. Set true for a public-subnet demo (SSH from ssh_ingress_cidrs); set false for a private subnet (use SSM Session Manager)."
+  type        = bool
+  default     = true
+}
+
+variable "db_security_group_id" {
+  description = "Security group attached to your MySQL database (RDS instance SG, Aurora cluster SG, or EC2 instance SG for self-hosted). An ingress rule on the MySQL port from the agent EC2 instance SG is added to it."
+  type        = string
+}
+
+variable "db_endpoint" {
+  description = "MySQL endpoint hostname (no port). For RDS, the RDS endpoint; for Aurora, the cluster writer endpoint; for self-hosted on EC2, the instance hostname or IP."
+  type        = string
+}
+
+variable "db_port" {
+  description = "MySQL TCP port."
+  type        = number
+  default     = 3306
+}
+
+variable "datadog_user" {
+  description = "MySQL user the Agent connects as. Must already exist (created out-of-band -- see README)."
+  type        = string
+  default     = "datadog"
+}
+
+variable "datadog_user_password" {
+  description = "Password for the datadog MySQL user. Lands in the conf.yaml on the EC2 instance -- see README security note."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key for the destination org."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_site" {
+  description = "Datadog site (datadoghq.com, datadoghq.eu, us3.datadoghq.com, etc.)."
+  type        = string
+  default     = "datadoghq.com"
+}
+
+variable "agent_image" {
+  description = "Datadog Agent container image. Pin to a digest or specific tag for reproducibility."
+  type        = string
+  default     = "public.ecr.aws/datadog/agent:7"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the Datadog Agent host."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "key_pair_name" {
+  description = "Name of an existing EC2 key pair for SSH access. Leave empty to skip SSH (use SSM Session Manager via the instance profile)."
+  type        = string
+  default     = ""
+}
+
+variable "ssh_ingress_cidrs" {
+  description = "CIDR blocks allowed to SSH into the EC2 instance. Empty list disables SSH ingress (use SSM)."
+  type        = list(string)
+  default     = []
+}
+
+variable "root_volume_size_gb" {
+  description = "EC2 root volume size in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "replication_enabled" {
+  description = "Set true if the monitored MySQL is a replica and you want replication metrics. Requires REPLICATION CLIENT grants on the datadog user (already covered in the manual SQL)."
+  type        = bool
+  default     = false
+}
+
+variable "schemas_collection_enabled" {
+  description = "Enable MySQL schemas collection (table/column/index metadata)."
+  type        = bool
+  default     = true
+}
+
+variable "agent_host_tags" {
+  description = "Tags applied to the MySQL instance via the check config (env, team, etc.)."
+  type        = list(string)
+  default     = ["env:demo", "team:dbm"]
+}

--- a/terraform/mysql/aws/ec2/versions.tf
+++ b/terraform/mysql/aws/ec2/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/mysql/aws/ecs-fargate/.gitignore
+++ b/terraform/mysql/aws/ecs-fargate/.gitignore
@@ -1,0 +1,16 @@
+# Sensitive credentials -- never commit these
+*.tfvars
+!*.tfvars.example
+
+# Terraform state (contains sensitive data)
+*.tfstate
+*.tfstate.*
+.terraform/
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/terraform/mysql/aws/ecs-fargate/README.md
+++ b/terraform/mysql/aws/ecs-fargate/README.md
@@ -1,0 +1,163 @@
+# DBM on ECS Fargate — MySQL in AWS
+
+Stands up a single Datadog Agent on **AWS ECS Fargate** with **Database Monitoring** enabled, configured to monitor an **existing MySQL database in AWS** via Autodiscovery.
+
+This is a bring-your-own-DB setup: it does **not** provision the database, a VPC, or the MySQL `datadog` user. It only deploys the agent into the VPC where your MySQL already lives, and opens the right ingress on the database's security group.
+
+Companion to the Postgres ECS Fargate sibling ([`../../postgres/aws/ecs-fargate/`](../../postgres/aws/ecs-fargate/)) — different database, same agent runtime.
+
+## Hosting coverage
+
+This module works for any MySQL database reachable inside an AWS VPC by security group. Point `db_endpoint` and `db_security_group_id` at:
+
+- **Amazon RDS MySQL** — the RDS endpoint and the RDS security group.
+- **Amazon Aurora MySQL** — the Aurora cluster writer endpoint and the Aurora cluster's security group.
+- **Self-hosted MySQL on EC2 in the same VPC** — the EC2 instance hostname/IP and the security group attached to the MySQL EC2 instance.
+
+For MySQL self-hosted **outside AWS** (on-premises, in another cloud), this AWS-side example does not apply.
+
+## Architecture
+
+```
+   ┌────────────────────────── existing VPC ──────────────────────────┐
+   │                                                                  │
+   │   private subnet (with NAT egress)            ┌──────────────┐   │
+   │   ┌────────────────────────┐    3306          │    MySQL     │   │
+   │   │  Fargate task          │ ───────────────▶ │  (RDS, or    │   │
+   │   │  datadog/agent:7       │                  │   Aurora, or │   │
+   │   │  ECS_FARGATE=true      │                  │   self-      │   │
+   │   │  AD: mysql + dbm       │                  │   hosted EC2)│   │
+   │   └─────────┬──────────────┘                  └──────────────┘   │
+   │             │ NAT egress                                         │
+   └─────────────┼────────────────────────────────────────────────────┘
+                 ▼
+            Datadog (DD_SITE)
+```
+
+## Prerequisites
+
+- **Terraform >= 1.5** and AWS credentials with permission to create ECS, IAM, security groups, and CloudWatch log groups in the target region.
+- **An existing MySQL database** (MySQL 5.7+ or 8.0+) — RDS, Aurora, or self-hosted on EC2.
+- **A private subnet in the database's VPC** that already has NAT egress to the internet (the agent must reach `*.${DD_SITE}`).
+- **RDS parameter group** (or `my.cnf` for self-hosted) with the following parameters set (Performance Schema is the source of truth for DBM):
+
+  | Parameter | Value | Why |
+  |---|---|---|
+  | `performance_schema` | `1` | Required for query metrics, samples, and activity |
+  | `max_digest_length` | `4096` | Larger captured SQL text |
+  | `performance_schema_max_digest_length` | `4096` | Match `max_digest_length` |
+  | `performance_schema_max_sql_text_length` | `4096` | Larger captured SQL text |
+
+  Changing `performance_schema` requires an RDS reboot.
+
+- **The MySQL `datadog` user** created on the database — see *Manual SQL* below.
+- A **Datadog API key** for the destination org.
+- (Optional) An **existing ECS cluster** in the target region. By default this template provisions a new cluster named `${name_prefix}-cluster`; set `existing_ecs_cluster_name` to attach the agent service to a cluster you already operate (recommended when you already run other Fargate services in the account).
+
+## Manual SQL
+
+Run this once against the MySQL instance using the master user.
+
+```sql
+-- Create the user
+CREATE USER datadog@'%' IDENTIFIED BY '<PASSWORD>';
+ALTER USER datadog@'%' WITH MAX_USER_CONNECTIONS 5;
+
+-- Required for monitoring
+GRANT REPLICATION CLIENT ON *.* TO datadog@'%';
+GRANT PROCESS ON *.* TO datadog@'%';
+GRANT SELECT ON performance_schema.* TO datadog@'%';
+
+-- Required for DBM (host metadata + explain plan capture)
+GRANT SELECT ON mysql.user TO datadog@'%';
+
+CREATE SCHEMA IF NOT EXISTS datadog;
+GRANT EXECUTE ON datadog.* TO datadog@'%';
+GRANT CREATE TEMPORARY TABLES ON datadog.* TO datadog@'%';
+
+DELIMITER $$
+CREATE PROCEDURE datadog.explain_statement(IN query TEXT)
+    SQL SECURITY DEFINER
+BEGIN
+    SET @explain := CONCAT('EXPLAIN FORMAT=json ', query);
+    PREPARE stmt FROM @explain;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+END $$
+DELIMITER ;
+
+-- Performance Schema consumers (run as master user, not as datadog)
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name LIKE 'events_statements_%';
+UPDATE performance_schema.setup_consumers SET enabled='YES' WHERE name = 'events_waits_current';
+```
+
+Reference: [Setup DBM for MySQL managed by AWS](https://docs.datadoghq.com/database_monitoring/setup_mysql/rds/).
+
+## Apply
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# fill in vpc_id, subnet_ids, db_security_group_id, db_endpoint,
+# datadog_user_password, datadog_api_key, and any optional overrides
+
+terraform init
+terraform plan
+terraform apply
+```
+
+`terraform apply` creates ~7 resources: ECS cluster (skipped if `existing_ecs_cluster_name` is set), task definition, service, task security group, ingress rule on the database's SG, IAM execution role (+ attachment), CloudWatch log group.
+
+## Verify
+
+1. Service is healthy:
+   ```bash
+   aws ecs describe-services \
+     --cluster $(terraform output -raw ecs_cluster_name) \
+     --services $(terraform output -raw ecs_service_name) \
+     --query 'services[0].{running:runningCount,desired:desiredCount,events:events[0:3]}'
+   ```
+2. Tail the agent logs and look for the `[mysql]` check running cleanly:
+   ```bash
+   aws logs tail $(terraform output -raw log_group_name) --follow
+   ```
+   You should see lines like `Running check mysql` and no `performance_schema` errors.
+3. In the Datadog UI:
+   - **Infrastructure → Containers**: the `datadog-agent` container appears.
+   - **Databases → List**: the MySQL host appears with DBM enabled.
+   - **Databases → Query Metrics**: rows render within ~2 minutes of database traffic.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+Removes the ECS resources and the ingress rule we added to the database's SG. The database, the VPC, and the MySQL `datadog` user are untouched. If you supplied `existing_ecs_cluster_name`, that cluster is also untouched (only the service we created on it is removed).
+
+## Security note
+
+The `datadog_user_password` is passed straight into the ECS task definition (Autodiscovery labels). Anyone with `ecs:DescribeTaskDefinition` on this account can read it. This is fine for a demo; for production, switch to **AWS Secrets Manager**:
+
+1. Store the password in a secret.
+2. Add `secretsmanager:GetSecretValue` to the execution role for that secret's ARN.
+3. Inject as `DD_MYSQL_PASSWORD` via `secrets[]` on the container.
+4. Reference in the AD instance as `password = "%%env_DD_MYSQL_PASSWORD%%"`.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Agent logs show `connection refused` to the database | Database SG ingress rule didn't apply, or task is in a subnet with no route to the database |
+| Agent logs show `performance_schema is disabled` | Parameter group missing `performance_schema=1`, or RDS not rebooted after the change |
+| Agent logs show `Access denied for user 'datadog'` | Manual SQL not run, or grants missing |
+| `query_metrics` empty but check is running | `events_statements_*` consumers not enabled in `performance_schema.setup_consumers` |
+| `query_samples` empty | `datadog.explain_statement` procedure not created, or `EXECUTE` not granted on `datadog.*` |
+| No data in Datadog UI | API key wrong, `DD_SITE` mismatched, or task can't reach `*.${DD_SITE}` (NAT egress missing) |
+
+## Files
+
+- `versions.tf` — Terraform + provider pins
+- `variables.tf` — inputs (secrets marked `sensitive`)
+- `main.tf` — ECS cluster, task def, service, IAM, SG, log group
+- `outputs.tf` — useful identifiers for verification
+- `terraform.tfvars.example` — fill-in-the-blanks template

--- a/terraform/mysql/aws/ecs-fargate/main.tf
+++ b/terraform/mysql/aws/ecs-fargate/main.tf
@@ -1,0 +1,152 @@
+# Security group for the Fargate task. Egress all (NAT gateway in the chosen
+# private subnet is responsible for reaching Datadog and the database over the VPC).
+resource "aws_security_group" "fargate_task" {
+  name        = "${var.name_prefix}-task-sg"
+  description = "Datadog Agent Fargate task - egress to Datadog and the MySQL database"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name_prefix}-task-sg" }
+}
+
+# Open MySQL ingress on the database's security group from the Fargate task SG.
+# Managed as a standalone rule so the database's SG itself stays untouched apart
+# from this single addition (and is cleanly removed on terraform destroy).
+resource "aws_security_group_rule" "db_ingress_from_fargate" {
+  type                     = "ingress"
+  description              = "Datadog Agent Fargate task to MySQL"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  security_group_id        = var.db_security_group_id
+  source_security_group_id = aws_security_group.fargate_task.id
+}
+
+resource "aws_cloudwatch_log_group" "datadog" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = var.log_retention_days
+
+  tags = { Name = "${var.name_prefix}-logs" }
+}
+
+resource "aws_iam_role" "ecs_execution" {
+  name = "${var.name_prefix}-ecs-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_execution" {
+  role       = aws_iam_role.ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Provision a new ECS cluster only when the caller hasn't supplied an existing
+# one. Reusing an existing cluster is the supported path for customers who
+# already run other Fargate services in the account.
+resource "aws_ecs_cluster" "main" {
+  count = var.existing_ecs_cluster_name == "" ? 1 : 0
+
+  name = "${var.name_prefix}-cluster"
+
+  tags = { Name = "${var.name_prefix}-cluster" }
+}
+
+locals {
+  ecs_cluster_name = var.existing_ecs_cluster_name != "" ? var.existing_ecs_cluster_name : aws_ecs_cluster.main[0].name
+}
+
+# Single-container task: the Datadog Agent. The MySQL check is configured
+# entirely via Autodiscovery dockerLabels (no file-based config needed).
+resource "aws_ecs_task_definition" "datadog" {
+  family                   = "${var.name_prefix}-agent"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "datadog-agent"
+      image     = var.agent_image
+      essential = true
+      environment = [
+        { name = "DD_API_KEY", value = var.datadog_api_key },
+        { name = "DD_SITE", value = var.datadog_site },
+        { name = "DD_HOSTNAME", value = "${var.name_prefix}-agent" },
+        { name = "ECS_FARGATE", value = "true" },
+        { name = "DD_APM_ENABLED", value = "false" },
+      ]
+      dockerLabels = {
+        "com.datadoghq.ad.check_names"  = jsonencode(["mysql"])
+        "com.datadoghq.ad.init_configs" = jsonencode([{}])
+        "com.datadoghq.ad.instances" = jsonencode([{
+          dbm      = true
+          host     = var.db_endpoint
+          port     = var.db_port
+          username = var.datadog_user
+          password = var.datadog_user_password
+          options = {
+            replication          = var.replication_enabled
+            extra_status_metrics = true
+            extra_innodb_metrics = true
+            schemas_collection = {
+              enabled = var.schemas_collection_enabled
+            }
+          }
+          query_metrics = {
+            enabled             = true
+            collection_interval = 10
+          }
+          query_samples = {
+            enabled             = true
+            collection_interval = 1
+          }
+          query_activity = {
+            enabled             = true
+            collection_interval = 10
+          }
+          tags = var.agent_host_tags
+        }])
+      }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.datadog.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "datadog-agent"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "datadog" {
+  name            = "${var.name_prefix}-service"
+  cluster         = local.ecs_cluster_name
+  task_definition = aws_ecs_task_definition.datadog.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [aws_security_group.fargate_task.id]
+    assign_public_ip = false
+  }
+
+  tags = { Name = "${var.name_prefix}-service" }
+}

--- a/terraform/mysql/aws/ecs-fargate/outputs.tf
+++ b/terraform/mysql/aws/ecs-fargate/outputs.tf
@@ -22,3 +22,8 @@ output "fargate_security_group_id" {
   description = "Security group attached to the Fargate task."
   value       = aws_security_group.fargate_task.id
 }
+
+output "db_ingress_rule_id" {
+  description = "ID of the security-group ingress rule added to the MySQL database's SG."
+  value       = aws_security_group_rule.db_ingress_from_fargate.id
+}

--- a/terraform/mysql/aws/ecs-fargate/outputs.tf
+++ b/terraform/mysql/aws/ecs-fargate/outputs.tf
@@ -1,0 +1,24 @@
+output "ecs_cluster_name" {
+  description = "ECS cluster running the Datadog Agent (the existing cluster you supplied, or the newly created one)."
+  value       = local.ecs_cluster_name
+}
+
+output "ecs_service_name" {
+  description = "ECS service name (use with aws ecs describe-services)."
+  value       = aws_ecs_service.datadog.name
+}
+
+output "task_definition_arn" {
+  description = "Latest task definition ARN."
+  value       = aws_ecs_task_definition.datadog.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for the agent container — tail with `aws logs tail <name> --follow`."
+  value       = aws_cloudwatch_log_group.datadog.name
+}
+
+output "fargate_security_group_id" {
+  description = "Security group attached to the Fargate task."
+  value       = aws_security_group.fargate_task.id
+}

--- a/terraform/mysql/aws/ecs-fargate/terraform.tfvars.example
+++ b/terraform/mysql/aws/ecs-fargate/terraform.tfvars.example
@@ -1,0 +1,31 @@
+aws_region = "us-east-1"
+
+# Existing networking around your MySQL database.
+# For RDS:         fill in from `aws rds describe-db-instances`.
+# For Aurora:      fill in from `aws rds describe-db-clusters`.
+# For self-hosted: use the EC2 instance's VPC + subnets + SG.
+vpc_id               = "vpc-0123456789abcdef0"
+subnet_ids           = ["subnet-aaaaaaaaaaaaaaaaa", "subnet-bbbbbbbbbbbbbbbbb"]
+db_security_group_id = "sg-0123456789abcdef0"
+
+# Optional — set to attach the agent service to an existing ECS cluster.
+# Leave empty (or omit) to provision a new "${name_prefix}-cluster".
+# existing_ecs_cluster_name = "my-shared-fargate-cluster"
+
+# MySQL connection details.
+# db_endpoint:
+#   - RDS:                the RDS endpoint
+#   - Aurora:             the cluster writer endpoint
+#   - self-hosted on EC2: the instance hostname or IP
+db_endpoint = "my-db.cluster-xxxxxxxxxxxx.us-east-1.rds.amazonaws.com"
+db_port     = 3306
+
+# Datadog MySQL user — already created on the DB (see README §Manual SQL).
+datadog_user          = "datadog"
+datadog_user_password = "REPLACE_ME"
+
+# Datadog destination.
+datadog_api_key = "REPLACE_ME"
+datadog_site    = "datadoghq.com"
+
+agent_host_tags = ["env:demo", "team:dbm", "service:mysql-fargate-demo"]

--- a/terraform/mysql/aws/ecs-fargate/variables.tf
+++ b/terraform/mysql/aws/ecs-fargate/variables.tf
@@ -1,0 +1,108 @@
+variable "aws_region" {
+  description = "AWS region where the ECS cluster runs. Should match the database's region."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix used for all resource names."
+  type        = string
+  default     = "dbm-mysql-fargate"
+}
+
+variable "vpc_id" {
+  description = "VPC where the MySQL database lives. The Fargate task is launched in this same VPC."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Private subnet IDs for the Fargate task. Must already have NAT egress so the agent can reach Datadog."
+  type        = list(string)
+}
+
+variable "db_security_group_id" {
+  description = "Security group attached to your MySQL database (RDS instance SG, Aurora cluster SG, or EC2 instance SG for self-hosted). An ingress rule on port 3306 from the Fargate task SG is added to it."
+  type        = string
+}
+
+variable "existing_ecs_cluster_name" {
+  description = "Name of an existing ECS cluster to attach the agent service to. Leave empty (default) to provision a new cluster named \"${name_prefix}-cluster\"."
+  type        = string
+  default     = ""
+}
+
+variable "db_endpoint" {
+  description = "MySQL endpoint hostname (no port). For RDS, the RDS endpoint; for Aurora, the cluster writer endpoint; for self-hosted on EC2, the instance hostname or IP."
+  type        = string
+}
+
+variable "db_port" {
+  description = "MySQL TCP port."
+  type        = number
+  default     = 3306
+}
+
+variable "datadog_user" {
+  description = "MySQL user the Agent connects as. Must already exist (created out-of-band — see README)."
+  type        = string
+  default     = "datadog"
+}
+
+variable "datadog_user_password" {
+  description = "Password for the datadog MySQL user. Lands in the ECS task definition — see README security note."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_api_key" {
+  description = "Datadog API key for the destination org."
+  type        = string
+  sensitive   = true
+}
+
+variable "datadog_site" {
+  description = "Datadog site (datadoghq.com, datadoghq.eu, us3.datadoghq.com, etc.)."
+  type        = string
+  default     = "datadoghq.com"
+}
+
+variable "agent_image" {
+  description = "Datadog Agent container image. Pin to a digest or specific tag for reproducibility."
+  type        = string
+  default     = "public.ecr.aws/datadog/agent:7"
+}
+
+variable "task_cpu" {
+  description = "Fargate task CPU units."
+  type        = string
+  default     = "512"
+}
+
+variable "task_memory" {
+  description = "Fargate task memory (MiB)."
+  type        = string
+  default     = "1024"
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention for the agent container logs."
+  type        = number
+  default     = 14
+}
+
+variable "replication_enabled" {
+  description = "Set true if the monitored MySQL is a replica and you want replication metrics. Requires REPLICATION CLIENT grants on the datadog user (already covered in the manual SQL)."
+  type        = bool
+  default     = false
+}
+
+variable "schemas_collection_enabled" {
+  description = "Enable MySQL schemas collection (table/column/index metadata)."
+  type        = bool
+  default     = true
+}
+
+variable "agent_host_tags" {
+  description = "Tags applied to the MySQL instance via the AD config (env, team, etc.)."
+  type        = list(string)
+  default     = ["env:demo", "team:dbm"]
+}

--- a/terraform/mysql/aws/ecs-fargate/versions.tf
+++ b/terraform/mysql/aws/ecs-fargate/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
## Summary

Adds all three MySQL agent-runtime examples, mirroring the shape of the Postgres examples from #8:

- **`terraform/mysql/aws/ec2/`** — Datadog Agent on Amazon Linux 2023 EC2 with DBM enabled. Agent config rendered via `yamlencode` into `conf.d/mysql.d/conf.yaml` and bind-mounted into the container.
- **`terraform/mysql/aws/ecs-fargate/`** — Datadog Agent on ECS Fargate with DBM enabled, configured via Autodiscovery `dockerLabels`. Supports BYO ECS cluster or provisions a new one.
- **`terraform/mysql/aws/amazon-eks/`** — Datadog Agent on EKS (EC2 node groups) with the MySQL check running as a cluster check on dedicated Cluster Check Runner pods. Supports BYO EKS cluster or greenfield mode.
- Updates `terraform/README.md`: adds all three MySQL runtimes to the availability table, makes the conventions section database-agnostic.

Each example is a self-contained Terraform module with `versions.tf`, `variables.tf`, `main.tf`, `outputs.tf`, `terraform.tfvars.example`, `.gitignore`, and a README covering prerequisites, apply/verify/teardown, security notes, and troubleshooting.

### Key design choices

| Decision | What |
|---|---|
| Generic variable names (`db_endpoint`, `db_port`, `db_security_group_id`) | Same module works for RDS, Aurora, and self-hosted on EC2 |
| Standalone `aws_security_group_rule` | `terraform destroy` removes only the rule we added; database SG is otherwise untouched |
| MySQL check in `clusterAgent.confd` (EKS) | Putting it under `datadog.confd` routes through node-agent autodiscovery, which the chart does not propagate to the cluster agent for CLC dispatch |
| Autodiscovery `dockerLabels` (ECS Fargate) | No file-based config needed; the whole check config lives in the task definition |
| `yamlencode` for `conf.yaml` (EC2) | Passwords/tags with `:`, `#`, quotes, or newlines round-trip safely |
| `http_put_response_hop_limit = 2` (EC2) | Keeps IMDSv2 reachable from bridge-networked Docker so the Agent can pick up EC2 metadata and AWS host tags |

### Fixes

- EC2 README: corrected display text of the Postgres sibling link
- ECS Fargate `outputs.tf`: added `db_ingress_rule_id` for consistency with the EKS module

## Test plan

### EC2
- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes
- [ ] `terraform apply` against an existing RDS MySQL: EC2 up, SSM session works, `docker ps` shows agent, `agent status` shows mysql check `Last Status: OK`
- [ ] Datadog UI: host in Infrastructure → Hosts, RDS host in Databases → List with DBM enabled, Query Metrics populate
- [ ] `terraform destroy` removes EC2 + IAM + host SG + RDS SG ingress rule; RDS instance untouched

### ECS Fargate
- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes
- [ ] `terraform apply` against an existing RDS MySQL: service running (`runningCount = 1`), agent logs show `Running check mysql`, no `performance_schema` errors
- [ ] `terraform apply` with `existing_ecs_cluster_name` set → no cluster created, service appears under supplied cluster
- [ ] Datadog UI: container in Infrastructure → Containers, RDS host in Databases → List with DBM enabled, Query Metrics populate
- [ ] `terraform destroy` removes ECS resources + RDS SG ingress rule; RDS instance untouched

### Amazon EKS
- [ ] `terraform fmt -check -recursive` passes
- [ ] `terraform validate` passes
- [ ] BYO mode: `terraform apply` against existing EKS cluster + RDS MySQL — mysql check assigned to CLC runner, `agent status` shows `Last Status: OK`, DBM data in Datadog UI
- [ ] BYO mode: `terraform destroy` removes helm release, namespace, and RDS SG ingress rule; EKS cluster untouched
- [ ] Greenfield mode: `terraform apply` provisions EKS cluster + node group + agent install (~13 resources)
- [ ] Greenfield mode: `terraform destroy` tears down EKS cluster, node group, and IAM cleanly; RDS untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)